### PR TITLE
Compatibility with 1.0861 beta branch; simplified .csproj

### DIFF
--- a/ModSettingsController.cs
+++ b/ModSettingsController.cs
@@ -307,7 +307,7 @@ namespace TrombSettings
 
         void GetSliderPrefab()
         {
-            GameObject slider = SettingsPanel.transform.Find("AUDIO/SET_sld_volume").gameObject;
+            GameObject slider = SettingsPanel.transform.Find("AUDIO/master_volume/SET_sld_volume").gameObject;
             GameObject _s = UnityEngine.Object.Instantiate(slider);
 
             RectTransform rect = _s.GetComponent<RectTransform>();

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]

--- a/TrombConfig.cs
+++ b/TrombConfig.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 namespace TrombSettings
 {
     [HarmonyPatch]
-    [BepInPlugin("com.hypersonicsharkz.trombsettings", "TrombSettings", "1.0.0")]
+    [BepInPlugin("com.hypersonicsharkz.trombsettings", "TrombSettings", "1.0.1")]
     public class TrombConfig : BaseUnityPlugin
     {
         public static TrombSettings TrombSettings = new TrombSettings();

--- a/TrombSettings.csproj
+++ b/TrombSettings.csproj
@@ -2,6 +2,9 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <GameFolder>E:\SteamLibrary\steamapps\common\TromboneChamp\</GameFolder>
+    <LibDir>$(GameFolder)\BepInEx\core\</LibDir>
+    <GameLibDir>$(GameFolder)\TromboneChamp_Data\Managed\</GameLibDir>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{92BF0427-C26C-4511-B674-66D4D166048B}</ProjectGuid>
@@ -32,21 +35,21 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\..\..\SteamLibrary\steamapps\common\TromboneChamp\BepInEx\core\0Harmony.dll</HintPath>
+      <HintPath>$(LibDir)\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\SteamLibrary\steamapps\common\TromboneChamp\TromboneChamp_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(GameLibDir)\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>..\..\..\SteamLibrary\steamapps\common\TromboneChamp\TromboneChamp_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>$(GameLibDir)\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx">
-      <HintPath>..\..\..\SteamLibrary\steamapps\common\TromboneChamp\BepInEx\core\BepInEx.dll</HintPath>
+      <HintPath>$(LibDir)\BepInEx.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization">
-      <HintPath>..\..\..\SteamLibrary\steamapps\common\TromboneChamp\TromboneChamp_Data\Managed\System.Runtime.Serialization.dll</HintPath>
+      <HintPath>$(GameLibDir)\System.Runtime.Serialization.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -55,20 +58,20 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\SteamLibrary\steamapps\common\TromboneChamp\TromboneChamp_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(GameLibDir)\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AudioModule">
-      <HintPath>..\..\..\SteamLibrary\steamapps\common\TromboneChamp\TromboneChamp_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+      <HintPath>$(GameLibDir)\UnityEngine.AudioModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\SteamLibrary\steamapps\common\TromboneChamp\TromboneChamp_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(GameLibDir)\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\SteamLibrary\steamapps\common\TromboneChamp\TromboneChamp_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>$(GameLibDir)\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\..\SteamLibrary\steamapps\common\TromboneChamp\TromboneChamp_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>$(GameLibDir)\UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -78,7 +81,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(TargetDir)$(ProjectName).dll" "D:\SteamLibrary\steamapps\common\TromboneChamp\BepInEx\plugins\$(ProjectName).dll"
-copy /Y "$(TargetDir)$(ProjectName).pdb" "D:\SteamLibrary\steamapps\common\TromboneChamp\BepInEx\plugins\$(ProjectName).pdb"</PostBuildEvent>
+    <PostBuildEvent>copy /Y "$(TargetDir)$(ProjectName).dll" "$(GameFolder)\BepInEx\plugins\$(ProjectName).dll"
+copy /Y "$(TargetDir)$(ProjectName).pdb" "$(GameFolder)\BepInEx\plugins\$(ProjectName).pdb"</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Hello HypersonicSharkz,

The dev(s) have started releasing beta builds for Trombone Champ which you can access via Steam. The latest beta changed the volume sliders which caused problems. This PR changes the path used to find the slider for the slider prefab. I also went ahead and added a property in the .csproj for GameFolder so it's easier to set up the project.